### PR TITLE
Run example pipeline on Expanse with Nextflow

### DIFF
--- a/seqera_pipeline_demo/cluster_manager.py
+++ b/seqera_pipeline_demo/cluster_manager.py
@@ -93,8 +93,8 @@ class SSHClusterBackend(ClusterBackend):
             connect_options={"known_hosts": None},
             worker_options={
                 "nthreads": threads_per_worker,
-                "memory_limit": memory_per_worker,
                 "preload": [preload_command],
+                "local_directory": config.get('local_directory', os.environ.get('SCRATCH_DIR')),
             },
             scheduler_options={
                 "port": scheduler_port,

--- a/seqera_pipeline_demo/nextflow.config
+++ b/seqera_pipeline_demo/nextflow.config
@@ -37,10 +37,10 @@ profiles {
       runOptions = '--env TMPDIR=$TMPDIR --env SCRATCH_DIR=$SCRATCH_DIR'
     }
 
-    timeline { enabled = true; file = "logs/nextflow_slurm_executor_timeline.html" }
-    report   { enabled = true; file = "logs/nextflow_slurm_executor_report.html"   }
-    trace    { enabled = true; file = "logs/nextflow_slurm_executor_trace.txt"     }
-    dag      { enabled = true; file = "logs/nextflow_slurm_executor_flowchart.png" }
+    timeline { enabled = true; file = "logs/nextflow_slurm_executor_timeline.html"; overwrite = true }
+    report   { enabled = true; file = "logs/nextflow_slurm_executor_report.html"; overwrite = true   }
+    trace    { enabled = true; file = "logs/nextflow_slurm_executor_trace.txt"; overwrite = true     }
+    dag      { enabled = true; file = "logs/nextflow_slurm_executor_flowchart.png"; overwrite = true }
   }
 }
 

--- a/seqera_pipeline_demo/nextflow.config
+++ b/seqera_pipeline_demo/nextflow.config
@@ -34,7 +34,7 @@ profiles {
     singularity {
       enabled = true
       autoMounts = true
-      runOptions = '--env TMPDIR=$TMPDIR'
+      runOptions = '--env TMPDIR=$TMPDIR --env SCRATCH_DIR=$SCRATCH_DIR'
     }
 
     timeline { enabled = true; file = "logs/nextflow_slurm_executor_timeline.html" }

--- a/seqera_pipeline_demo/nextflow.config
+++ b/seqera_pipeline_demo/nextflow.config
@@ -1,7 +1,7 @@
 profiles {
   slurm_debug {
-    workDir = "./output/nxf_work"
-    params.outdir = "./output/results"
+    workDir = "/expanse/lustre/scratch/${System.env.USER}/temp_project/nxf_work"
+    params.outdir = "/expanse/lustre/scratch/${System.env.USER}/temp_project/results_debug"
 
     process {
       executor = 'slurm'

--- a/seqera_pipeline_demo/nextflow.config
+++ b/seqera_pipeline_demo/nextflow.config
@@ -1,0 +1,52 @@
+profiles {
+  slurm_debug {
+    workDir = "./output/nxf_work"
+    params.outdir = "./output/results"
+
+    process {
+      executor = 'slurm'
+      queue    = 'debug'
+      time     = '00:10:00'
+      cpus     = 2
+      memory   = '4 GB'
+
+      clusterOptions = '--account=sds166 --nodes=1 --ntasks=1 -o logs/%x-%j.out -e logs/%x-%j.err'
+
+
+      // Use node-local scratch on Expanse
+      scratch = true
+      beforeScript = '''
+        set -euo pipefail
+        export SCRATCH_DIR="/scratch/$USER/job_${SLURM_JOB_ID}"
+        mkdir -p "$SCRATCH_DIR/tmp"
+        export TMPDIR="$SCRATCH_DIR/tmp"
+        export NXF_OPTS="-Djava.io.tmpdir=$TMPDIR"
+        echo "[NF] Using node-local scratch at: $SCRATCH_DIR"
+      '''
+    }
+
+    executor {
+      queueSize = 1          // only 1 job queued at a time
+      submitRateLimit = '1 sec'
+      pollInterval = '10 sec'
+    }
+
+    singularity {
+      enabled = true
+      autoMounts = true
+      runOptions = '--env TMPDIR=$TMPDIR'
+    }
+
+    timeline { enabled = true; file = "logs/nextflow_slurm_executor_timeline.html" }
+    report   { enabled = true; file = "logs/nextflow_slurm_executor_report.html"   }
+    trace    { enabled = true; file = "logs/nextflow_slurm_executor_trace.txt"     }
+    dag      { enabled = true; file = "logs/nextflow_slurm_executor_flowchart.png" }
+  }
+}
+
+params {
+  input_obs_dir = "obs_TEST.pffd" // Default input observation directory
+  output_l0_dir = "L0_zarr"
+  output_l1_dir = "L1_zarr"
+  config_file = "config.toml"
+}

--- a/seqera_pipeline_demo/nextflow.config
+++ b/seqera_pipeline_demo/nextflow.config
@@ -7,8 +7,8 @@ profiles {
       executor = 'slurm'
       queue    = 'debug'
       time     = '00:10:00'
-      cpus     = 128
-      memory   = '256 GB'
+      cpus     = 16
+      memory   = '32 GB'
 
       clusterOptions = '--account=sds166 --nodes=1 --ntasks=1 -o logs/%x-%j.out -e logs/%x-%j.err'
 

--- a/seqera_pipeline_demo/nextflow.config
+++ b/seqera_pipeline_demo/nextflow.config
@@ -7,8 +7,8 @@ profiles {
       executor = 'slurm'
       queue    = 'debug'
       time     = '00:10:00'
-      cpus     = 2
-      memory   = '4 GB'
+      cpus     = 128
+      memory   = '256 GB'
 
       clusterOptions = '--account=sds166 --nodes=1 --ntasks=1 -o logs/%x-%j.out -e logs/%x-%j.err'
 

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -1,0 +1,64 @@
+#!/usr/bin/env nextflow
+
+// Define parameters
+params.input_obs_dir = "obs_TEST.pffd"
+params.output_l0_dir = "L0_zarr"
+params.output_l1_dir = "L1_zarr"
+params.config_file = "config.toml"
+
+// Process for step1_pff_to_zarr.py
+process pff_to_zarr {
+    publishDir "${params.outdir}/${params.output_l0_dir}", mode: 'copy'
+
+    input:
+        path obs_dir
+        path config_file
+
+    output:
+        path "${params.output_l0_dir}" // Output L0 Zarr directory
+
+    script:
+    """
+    uv run python step1_pff_to_zarr.py \
+        ${obs_dir} \
+        ${params.output_l0_dir} \
+        ${config_file}
+    """
+}
+
+// Process for step2_dask_baseline.py
+process dask_baseline {
+    publishDir "${params.outdir}/${params.output_l1_dir}", mode: 'copy'
+
+    input:
+        path l0_zarr_base_dir // This will be the base directory for L0 Zarrs
+        path config_file
+
+    output:
+        path "${params.output_l1_dir}" // Output L1 Zarr directory
+
+    script:
+    """
+    # Find all L0 Zarr directories within the input l0_zarr_base_dir
+    find ${l0_zarr_base_dir} -maxdepth 1 -type d -name "*.zarr" | while read L0_ZARR; do
+        BASENAME_ZARR=$(basename "$L0_ZARR" .zarr)
+        L1_ZARR="${params.output_l1_dir}/${BASENAME_ZARR}_L1.zarr"
+        uv run python step2_dask_baseline.py \
+            "$L0_ZARR" \
+            "$L1_ZARR" \
+            --config "${config_file}"
+    done
+    """
+}
+
+workflow {
+    // Create channels for inputs
+    input_obs_ch = Channel.fromPath(params.input_obs_dir)
+    config_file_ch = Channel.fromPath(params.config_file)
+
+    // Run pff_to_zarr process
+    pff_to_zarr(input_obs_ch, config_file_ch)
+
+    // Run dask_baseline process, taking output from pff_to_zarr
+    dask_baseline(pff_to_zarr.out, config_file_ch)
+}

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -45,12 +45,7 @@ process dask_baseline {
     """
     # Find all L0 Zarr directories within the input l0_zarr_base_dir
     find ${l0_zarr_base_dir} -maxdepth 1 -type d -name "*.zarr" | while read L0_ZARR; do
-        BASENAME_ZARR=\$(basename "\$L0_ZARR" .zarr)
-        L1_ZARR="${params.output_l1_dir}/\${BASENAME_ZARR}_L1.zarr"
-        python ${step2_script} \
-            "$L0_ZARR" \
-            "$L1_ZARR" \
-            --config "${config_file}"
+        BASENAME_ZARR=\\$(basename \"\\\${L0_ZARR}\" .zarr)\n        L1_ZARR=\"${params.output_l1_dir}/\\${BASENAME_ZARR}_L1.zarr\"\n        python ${step2_script} \\\n            \"\\\${L0_ZARR}\" \\\n            \"$L1_ZARR\" \\\n            --config \"${config_file}\"
     done
     """
 }

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -41,7 +41,7 @@ process dask_baseline {
     """
     # Find all L0 Zarr directories within the input l0_zarr_base_dir
     find ${l0_zarr_base_dir} -maxdepth 1 -type d -name "*.zarr" | while read L0_ZARR; do
-        BASENAME_ZARR=$(basename "$L0_ZARR" .zarr)
+        BASENAME_ZARR=\$(basename "\$L0_ZARR" .zarr)
         L1_ZARR="${params.output_l1_dir}/${BASENAME_ZARR}_L1.zarr"
         uv run python step2_dask_baseline.py \
             "$L0_ZARR" \

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -9,7 +9,7 @@ params.config_file = "config.toml"
 // Process for step1_pff_to_zarr.py
 process pff_to_zarr {
     publishDir "${params.outdir}/${params.output_l0_dir}", mode: 'copy'
-    container 'oras://community.wave.seqera.io/library/pip_blosc_dask_distributed_pruned:c32f1c56c9a5c26c'
+    container 'oras://ghcr.io/zonca/singularity_dask_zarr:latest'
 
     input:
         path obs_dir
@@ -31,7 +31,7 @@ process pff_to_zarr {
 process dask_baseline {
     publishDir "${params.outdir}/${params.output_l1_dir}", mode: 'copy'
 
-    container 'oras://community.wave.seqera.io/library/pip_blosc_dask_distributed_pruned:c32f1c56c9a5c26c'
+    container 'oras://ghcr.io/zonca/singularity_dask_zarr:latest'
     input:
         path l0_zarr_base_dir // This will be the base directory for L0 Zarrs
         path config_file

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -14,7 +14,7 @@ process pff_to_zarr {
     input:
         path obs_dir
         path config_file
-        path step1_script from file("step1_pff_to_zarr.py")
+        path step1_script
 
     output:
         path "${params.output_l0_dir}" // Output L0 Zarr directory
@@ -36,7 +36,7 @@ process dask_baseline {
     input:
         path l0_zarr_base_dir // This will be the base directory for L0 Zarrs
         path config_file
-        path step2_script from file("step2_dask_baseline.py")
+        path step2_script
 
     output:
         path "${params.output_l1_dir}" // Output L1 Zarr directory
@@ -59,10 +59,12 @@ workflow {
     // Create channels for inputs
     input_obs_ch = Channel.fromPath(params.input_obs_dir)
     config_file_ch = Channel.fromPath(params.config_file)
+    step1_script_ch = Channel.fromPath("step1_pff_to_zarr.py")
+    step2_script_ch = Channel.fromPath("step2_dask_baseline.py")
 
     // Run pff_to_zarr process
-    pff_to_zarr(input_obs_ch, config_file_ch)
+    pff_to_zarr(input_obs_ch, config_file_ch, step1_script_ch)
 
     // Run dask_baseline process, taking output from pff_to_zarr
-    dask_baseline(pff_to_zarr.out, config_file_ch)
+    dask_baseline(pff_to_zarr.out, config_file_ch, step2_script_ch)
 }

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -19,7 +19,7 @@ process pff_to_zarr {
 
     script:
     """
-    uv run python step1_pff_to_zarr.py \
+    python step1_pff_to_zarr.py \
         ${obs_dir} \
         ${params.output_l0_dir} \
         ${config_file}
@@ -43,7 +43,7 @@ process dask_baseline {
     find ${l0_zarr_base_dir} -maxdepth 1 -type d -name "*.zarr" | while read L0_ZARR; do
         BASENAME_ZARR=\$(basename "\$L0_ZARR" .zarr)
         L1_ZARR="${params.output_l1_dir}/${BASENAME_ZARR}_L1.zarr"
-        uv run python step2_dask_baseline.py \
+        python step2_dask_baseline.py \
             "$L0_ZARR" \
             "$L1_ZARR" \
             --config "${config_file}"

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -45,7 +45,12 @@ process dask_baseline {
     """
     # Find all L0 Zarr directories within the input l0_zarr_base_dir
     find ${l0_zarr_base_dir} -maxdepth 1 -type d -name "*.zarr" | while read L0_ZARR; do
-        BASENAME_ZARR=\\$(basename \"\\\${L0_ZARR}\" .zarr)\n        L1_ZARR=\"${params.output_l1_dir}/\\${BASENAME_ZARR}_L1.zarr\"\n        python ${step2_script} \\\n            \"\\\${L0_ZARR}\" \\\n            \"$L1_ZARR\" \\\n            --config \"${config_file}\"
+        BASENAME_ZARR=\$(basename "\$L0_ZARR" .zarr)
+        L1_ZARR="${params.output_l1_dir}/\$BASENAME_ZARR_L1.zarr"
+        python ${step2_script} \
+            "\$L0_ZARR" \
+            "\$L1_ZARR" \
+            --config "${config_file}"
     done
     """
 }

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -46,7 +46,7 @@ process dask_baseline {
     # Find all L0 Zarr directories within the input l0_zarr_base_dir
     find ${l0_zarr_base_dir} -maxdepth 1 -type d -name "*.zarr" | while read L0_ZARR; do
         BASENAME_ZARR=\$(basename "\$L0_ZARR" .zarr)
-        L1_ZARR="${params.output_l1_dir}/${BASENAME_ZARR}_L1.zarr"
+        L1_ZARR="${params.output_l1_dir}/\${BASENAME_ZARR}_L1.zarr"
         python ${step2_script} \
             "$L0_ZARR" \
             "$L1_ZARR" \

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -9,6 +9,7 @@ params.config_file = "config.toml"
 // Process for step1_pff_to_zarr.py
 process pff_to_zarr {
     publishDir "${params.outdir}/${params.output_l0_dir}", mode: 'copy'
+    container 'oras://community.wave.seqera.io/library/pip_blosc_dask_distributed_pruned:c32f1c56c9a5c26c'
 
     input:
         path obs_dir
@@ -30,6 +31,7 @@ process pff_to_zarr {
 process dask_baseline {
     publishDir "${params.outdir}/${params.output_l1_dir}", mode: 'copy'
 
+    container 'oras://community.wave.seqera.io/library/pip_blosc_dask_distributed_pruned:c32f1c56c9a5c26c'
     input:
         path l0_zarr_base_dir // This will be the base directory for L0 Zarrs
         path config_file

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -43,6 +43,9 @@ process dask_baseline {
 
     script:
     """
+    # Create the output L1 Zarr directory if it doesn't exist
+    mkdir -p ${params.output_l1_dir}
+
     # Find all L0 Zarr directories within the input l0_zarr_base_dir
     find ${l0_zarr_base_dir} -maxdepth 1 -type d -name "*.zarr" | while read L0_ZARR; do
         BASENAME_ZARR=\$(basename "\$L0_ZARR" .zarr)

--- a/seqera_pipeline_demo/pipeline.nf
+++ b/seqera_pipeline_demo/pipeline.nf
@@ -14,13 +14,14 @@ process pff_to_zarr {
     input:
         path obs_dir
         path config_file
+        path step1_script from file("step1_pff_to_zarr.py")
 
     output:
         path "${params.output_l0_dir}" // Output L0 Zarr directory
 
     script:
     """
-    python step1_pff_to_zarr.py \
+    python ${step1_script} \
         ${obs_dir} \
         ${params.output_l0_dir} \
         ${config_file}
@@ -35,6 +36,7 @@ process dask_baseline {
     input:
         path l0_zarr_base_dir // This will be the base directory for L0 Zarrs
         path config_file
+        path step2_script from file("step2_dask_baseline.py")
 
     output:
         path "${params.output_l1_dir}" // Output L1 Zarr directory
@@ -45,7 +47,7 @@ process dask_baseline {
     find ${l0_zarr_base_dir} -maxdepth 1 -type d -name "*.zarr" | while read L0_ZARR; do
         BASENAME_ZARR=\$(basename "\$L0_ZARR" .zarr)
         L1_ZARR="${params.output_l1_dir}/${BASENAME_ZARR}_L1.zarr"
-        python step2_dask_baseline.py \
+        python ${step2_script} \
             "$L0_ZARR" \
             "$L1_ZARR" \
             --config "${config_file}"

--- a/seqera_pipeline_demo/run_expanse.sh
+++ b/seqera_pipeline_demo/run_expanse.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Run the Nextflow pipeline on Expanse using the slurm_debug profile
+
+echo "Starting Nextflow pipeline on Expanse..."
+
+# You can override parameters by adding them to the command, e.g.:
+# --input_obs_dir my_custom_obs.pffd \
+# --output_l0_dir my_l0_output \
+# --output_l1_dir my_l1_output \
+# --config_file my_custom_config.toml
+
+nextflow run pipeline.nf -profile slurm_debug
+
+echo "Nextflow pipeline submitted."
+

--- a/seqera_pipeline_demo/step2_dask_baseline.py
+++ b/seqera_pipeline_demo/step2_dask_baseline.py
@@ -327,7 +327,7 @@ async def baseline_subtract_dask(zarr_input: str, zarr_output: str, config: dict
         if use_distributed:
             print("Computing with Dask cluster...")
             futures = client.compute(store_operation)
-            result = await client.gather(futures)
+            result = client.gather(futures)
         else:
             print("Computing locally with Dask...")
             with ProgressBar():
@@ -418,10 +418,14 @@ Examples:
         # Close client connection and shutdown local cluster if it was started by this script
         if client:
             print("\n  ✓ Closing Dask client...")
-            await client.close()
+            close_future = client.close()
+            if close_future is not None:
+                await close_future
         if local_cluster:
             print("  ✓ Shutting down local Dask cluster...")
-            await local_cluster.close()
+            close_future_cluster = local_cluster.close()
+            if close_future_cluster is not None:
+                await close_future_cluster
 
 
 def main():

--- a/seqera_pipeline_demo/step2_dask_baseline.py
+++ b/seqera_pipeline_demo/step2_dask_baseline.py
@@ -21,7 +21,7 @@ import dask
 import dask.array as da
 from pathlib import Path
 import time
-from dask.distributed import Client, wait
+from dask.distributed import Client, wait, LocalCluster
 from dask.diagnostics import ProgressBar
 
 # Try to import tomli/tomllib
@@ -71,21 +71,31 @@ def load_config(config_path: str = "config.toml"):
 
 
 async def connect_to_dask(scheduler_address: str):
-    """Connect to existing Dask scheduler"""
+    """Connect to existing Dask scheduler or start a local one"""
+    client = None
+    cluster = None
     if not scheduler_address:
-        print("No Dask scheduler address provided - using local threading")
-        return None
+        print("No Dask scheduler address provided - starting a local Dask cluster")
+        try:
+            cluster = LocalCluster(n_workers=os.cpu_count() or 4, processes=True, threads_per_worker=1)
+            client = await Client(cluster, asynchronous=True)
+            print(f"  ✓ Local Dask cluster started at: {client.scheduler_info()['address']}")
+            return client, cluster
+        except Exception as e:
+            print(f"Error starting local Dask cluster: {e}")
+            print("Falling back to local threading")
+            return None, None
 
     try:
         print(f"Connecting to Dask scheduler: {scheduler_address}")
         client = await Client(scheduler_address, asynchronous=True)
         worker_info = client.scheduler_info()
         print(f"  ✓ Connected! Workers: {len(worker_info['workers'])}")
-        return client
+        return client, None # No local cluster to manage if connecting to existing
     except Exception as e:
         print(f"Warning: Could not connect to Dask scheduler: {e}")
         print("Falling back to local threading")
-        return None
+        return None, None
 
 
 def detect_data_product(zarr_path: str) -> str:
@@ -396,16 +406,22 @@ Examples:
 
     # Connect to Dask cluster if scheduler provided
     client = None
+    local_cluster = None
     if args.dask_scheduler:
-        client = await connect_to_dask(args.dask_scheduler)
+        client, local_cluster = await connect_to_dask(args.dask_scheduler)
+    else:
+        client, local_cluster = await connect_to_dask(None) # Call with None to trigger local cluster creation
 
     try:
         await baseline_subtract_dask(args.input_zarr, args.output_zarr, config, client)
     finally:
-        # Close client connection (but don't shutdown cluster)
+        # Close client connection and shutdown local cluster if it was started by this script
         if client:
-            print("\n  Keeping cluster alive for next task...")
+            print("\n  ✓ Closing Dask client...")
             await client.close()
+        if local_cluster:
+            print("  ✓ Shutting down local Dask cluster...")
+            await local_cluster.close()
 
 
 def main():


### PR DESCRIPTION
Nextflow is the workflow engine behind Seqera.

In this test I run the 2 jobs in this pipeline using Nextflow.

The output I get on Expanse is:

```
Starting Nextflow pipeline on Expanse...                 
                                    
 N E X T F L O W   ~  version 25.04.8               

Launching `pipeline.nf` [angry_perlman] DSL2 - revision: 1a4505e359
                                                                        
executor >  slurm (2)                
[e6/f1c658] pff_to_zarr (1)   [100%] 1 of 1 ✔
[4c/219cb6] dask_baseline (1) [100%] 1 of 1 ✔
Completed at: 07-Oct-2025 16:04:27
Duration    : 2m 42s   
CPU hours   : 0.1      
Succeeded   : 2        
                                    
                                    
Nextflow pipeline submitted.
```

So, I am on the login node, I run the workflow and for each step Nextflow launches a SLURM job of 1 node, inside that job it runs a Singularity container and launches a small dask cluster and then runs the code.

To learn about Nextflow see:

* The Hello Nextflow tutorial: https://training.nextflow.io/latest/hello_nextflow/
* My tutorial on using it on Expanse using SLURM and Singularity https://www.zonca.dev/posts/2025-10-07-running-nextflow-on-expanse
